### PR TITLE
feat(ui): Añadir funcionalidad para reiniciar la grabación de voz

### DIFF
--- a/frontend/src/app/voice-chat/page.tsx
+++ b/frontend/src/app/voice-chat/page.tsx
@@ -26,6 +26,7 @@ export default function VoiceChatPage() {
     startUserSpeaking,
     stopUserSpeaking,
     processInteraction,
+    restartRecording,
   } = useLumenChat();
 
   // estados locales de la ui
@@ -137,6 +138,7 @@ export default function VoiceChatPage() {
           handleEndCall={handleEndCall}
           handleStopAndProcess={handleStopAndProcess}
           setShowSettings={setShowSettings}
+          restartRecording={restartRecording}
         />
       ) : (
         <VoiceChatDesktopLayout
@@ -161,6 +163,7 @@ export default function VoiceChatPage() {
           handleEndCall={handleEndCall}
           handleStopAndProcess={handleStopAndProcess}
           setShowSettings={setShowSettings}
+          restartRecording={restartRecording}
         />
       )}
 

--- a/frontend/src/features/voice-chat/components/VoiceChatDesktopLayout.tsx
+++ b/frontend/src/features/voice-chat/components/VoiceChatDesktopLayout.tsx
@@ -8,12 +8,12 @@ import {
   MicOff,
   Video,
   VideoOff,
-  MoreHorizontal,
   X,
   Settings,
   LoaderCircle,
   Square,
   MessageSquareText,
+  RotateCcw,
 } from "lucide-react";
 import {
   ResizableHandle,
@@ -60,6 +60,7 @@ interface VoiceChatDesktopLayoutProps {
   handleEndCall: () => void;
   handleStopAndProcess: () => void;
   setShowSettings: (show: boolean) => void;
+  restartRecording: () => void;
 }
 
 export default function VoiceChatDesktopLayout({
@@ -84,6 +85,7 @@ export default function VoiceChatDesktopLayout({
   handleEndCall,
   handleStopAndProcess,
   setShowSettings,
+  restartRecording,
 }: VoiceChatDesktopLayoutProps) {
   return (
     <ResizablePanelGroup direction="horizontal" className="w-full h-full">
@@ -243,9 +245,11 @@ export default function VoiceChatDesktopLayout({
               <Button
                 variant="ghost"
                 size="icon"
-                className="rounded-full w-12 h-12 text-gray-400 hover:text-white hover:bg-gray-700"
+                onClick={restartRecording}
+                disabled={!isUserSpeaking || isProcessing || isAISpeaking}
+                className="rounded-full w-12 h-12 text-gray-400 hover:text-white hover:bg-gray-700 disabled:opacity-50"
               >
-                <MoreHorizontal className="w-5 h-5" />
+                <RotateCcw className="w-5 h-5" />
               </Button>
               <Button
                 variant="ghost"

--- a/frontend/src/features/voice-chat/components/VoiceChatMobileLayout.tsx
+++ b/frontend/src/features/voice-chat/components/VoiceChatMobileLayout.tsx
@@ -13,6 +13,7 @@ import {
   LoaderCircle,
   Square,
   MessageSquareText,
+  RotateCcw,
 } from "lucide-react";
 import {
   Accordion,
@@ -54,6 +55,7 @@ interface VoiceChatMobileLayoutProps {
   handleEndCall: () => void;
   handleStopAndProcess: () => void;
   setShowSettings: (show: boolean) => void;
+  restartRecording: () => void;
 }
 
 export default function VoiceChatMobileLayout({
@@ -78,6 +80,7 @@ export default function VoiceChatMobileLayout({
   handleEndCall,
   handleStopAndProcess,
   setShowSettings,
+  restartRecording,
 }: VoiceChatMobileLayoutProps) {
   return (
     <div className="flex flex-col h-full">
@@ -200,6 +203,15 @@ export default function VoiceChatMobileLayout({
               ) : (
                 <VideoOff className="w-4 h-4" />
               )}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={restartRecording}
+              disabled={!isUserSpeaking || isProcessing || isAISpeaking}
+              className="rounded-full w-10 h-10 text-gray-400 hover:text-white hover:bg-gray-700 disabled:opacity-50"
+            >
+              <RotateCcw className="w-4 h-4" />
             </Button>
             <Button
               variant="ghost"

--- a/frontend/src/features/voice-chat/hooks/use-lumen-chat.ts
+++ b/frontend/src/features/voice-chat/hooks/use-lumen-chat.ts
@@ -173,28 +173,35 @@ export const useLumenChat = () => {
 
   const stopRecording = useCallback(() => {
     return new Promise<Blob>((resolve) => {
-      if (
-        mediaRecorderRef.current &&
-        mediaRecorderRef.current.state === "recording"
-      ) {
-        mediaRecorderRef.current.onstop = () => {
+      const recorder = mediaRecorderRef.current; // capturar la instancia actual
+
+      if (recorder && recorder.state === "recording") {
+        // asignar el handler de 'onstop' a la instancia capturada
+        recorder.onstop = () => {
           const audioBlob = new Blob(audioChunksRef.current, {
             type: "audio/webm",
           });
           audioChunksRef.current = [];
-          const stream = mediaRecorderRef.current?.stream;
+          // usar el stream de la instancia capturada para la limpieza
+          const stream = recorder.stream;
           if (stream) {
             stream.getTracks().forEach((track) => track.stop());
           }
           resolve(audioBlob);
         };
-        mediaRecorderRef.current.stop();
+
+        recorder.stop();
         setIsUserSpeaking(false);
       } else {
         resolve(new Blob());
       }
     });
   }, []);
+
+  const restartRecording = useCallback(async () => {
+    await stopRecording();
+    startRecording();
+  }, [stopRecording, startRecording]);
 
   return {
     isAISpeaking,
@@ -209,5 +216,6 @@ export const useLumenChat = () => {
     startUserSpeaking: startRecording,
     stopUserSpeaking: stopRecording,
     processInteraction,
+    restartRecording,
   };
 };


### PR DESCRIPTION
Este Pull Request introduce una mejora en la experiencia de usuario al añadir un botón de "Reiniciar Grabación" en la barra de controles.

**¿Qué cambia?**
- Permite a los usuarios descartar su grabación de audio actual y comenzar una nueva de inmediato, sin necesidad de enviar el audio o esperar a que termine el procesamiento.
- Esto es especialmente útil si el usuario comete un error al hablar y desea corregirlo antes de enviarlo.

**Implementación:**
- Se ha añadido una nueva función `restartRecording` en el hook `useLumenChat`.
- Se ha integrado el nuevo botón en los layouts de escritorio y móvil.
- Se incluye una pequeña corrección en la función `stopRecording` para hacerla más robusta.